### PR TITLE
Added support for multi field lookups to object cache

### DIFF
--- a/multi_import/importer.py
+++ b/multi_import/importer.py
@@ -54,7 +54,7 @@ class Importer(object):
         return CachedQuery(self.queryset, self.lookup_fields)
 
     def lookup_model_object(self, lookup_data):
-        return self.cached_query.lookup(self.lookup_fields, lookup_data)
+        return self.cached_query.match(lookup_data, self.lookup_fields)
 
     def enumerate_data(self, data):
         """

--- a/multi_import/relations.py
+++ b/multi_import/relations.py
@@ -61,7 +61,7 @@ class LookupRelatedField(relations.RelatedField):
     def search_new_objects(self, value):
         new_object_cache = self.new_object_cache
         if new_object_cache:
-            match = new_object_cache.lookup_value(value)
+            match = new_object_cache.find(value, self.lookup_fields)
             if match:
                 return match
 

--- a/tests/test_object_cache.py
+++ b/tests/test_object_cache.py
@@ -6,9 +6,10 @@ from tests.models import Book
 
 
 class MyClass(object):
-    def __init__(self, arg1=None, arg2=None):
+    def __init__(self, arg1=None, arg2=None, arg3=None):
         self.arg1 = arg1
         self.arg2 = arg2
+        self.arg3 = arg3
 
 
 class CachedObjectTests(TestCase):
@@ -67,6 +68,20 @@ class ObjectCacheTests(TestCase):
 
         self.assertEqual(obj, result)
 
+    def test_lookup__value_pair(self):
+        lookup_fields = ('arg1', ('arg2', 'arg3'))
+        cache = ObjectCache(lookup_fields)
+        obj1 = MyClass(1, 2, 3)
+        obj2 = MyClass(1, 2, 4)
+        obj3 = MyClass(1, 4, 3)
+
+        cache.cache_instance(obj1)
+        cache.cache_instance(obj2)
+        cache.cache_instance(obj3)
+        result = cache.lookup(lookup_fields, {'arg1': 2, 'arg2': 2, 'arg3': 3})
+
+        self.assertEqual(obj1, result)
+
     def test_lookup__not_match(self):
         lookup_fields = ('arg1',)
         cache = ObjectCache(lookup_fields)
@@ -98,6 +113,34 @@ class ObjectCacheTests(TestCase):
         result = cache.lookup_value(1)
 
         self.assertEqual(obj, result)
+
+    def test_lookup_value__value_pair(self):
+        lookup_fields = ('arg1', ('arg2', 'arg3'))
+        cache = ObjectCache(lookup_fields)
+        obj1 = MyClass(1, 2, 3)
+        obj2 = MyClass(1, 2, 4)
+        obj3 = MyClass(1, 4, 3)
+
+        cache.cache_instance(obj1)
+        cache.cache_instance(obj2)
+        cache.cache_instance(obj3)
+        result = cache.lookup_value([2, 3])
+
+        self.assertEqual(obj1, result)
+
+    def test_lookup_value__value_pair_not_found(self):
+        lookup_fields = ('arg1', ('arg2', 'arg3'))
+        cache = ObjectCache(lookup_fields)
+        obj1 = MyClass(1, 2, 3)
+        obj2 = MyClass(1, 2, 4)
+        obj3 = MyClass(1, 4, 3)
+
+        cache.cache_instance(obj1)
+        cache.cache_instance(obj2)
+        cache.cache_instance(obj3)
+        result = cache.lookup_value([1, 3])
+
+        self.assertIsNone(result)
 
     def test_lookup_value__not_found(self):
         lookup_fields = ('arg1',)

--- a/tests/test_object_cache.py
+++ b/tests/test_object_cache.py
@@ -42,7 +42,7 @@ class ObjectCacheTests(TestCase):
         obj = MyClass(1, 2)
         default = MyClass()
 
-        cache.cache_instance(obj)
+        cache.add(obj)
         result = cache.get('arg1', 1, default)
 
         self.assertEqual(obj, result)
@@ -53,116 +53,88 @@ class ObjectCacheTests(TestCase):
         obj = MyClass()
         default = MyClass(1, 2)
 
-        cache.cache_instance(obj)
+        cache.add(obj)
         result = cache.get('arg1', None, default)
 
         self.assertEqual(default, result)
 
-    def test_lookup(self):
+    def test_find(self):
         lookup_fields = ('arg1',)
         cache = ObjectCache(lookup_fields)
         obj = MyClass(1, 2)
 
-        cache.cache_instance(obj)
-        result = cache.lookup(lookup_fields, {'arg1': 1})
+        cache.add(obj)
+        result = cache.find(1)
 
         self.assertEqual(obj, result)
 
-    def test_lookup__value_pair(self):
-        lookup_fields = ('arg1', ('arg2', 'arg3'))
-        cache = ObjectCache(lookup_fields)
-        obj1 = MyClass(1, 2, 3)
-        obj2 = MyClass(1, 2, 4)
-        obj3 = MyClass(1, 4, 3)
-
-        cache.cache_instance(obj1)
-        cache.cache_instance(obj2)
-        cache.cache_instance(obj3)
-        result = cache.lookup(lookup_fields, {'arg1': 2, 'arg2': 2, 'arg3': 3})
-
-        self.assertEqual(obj1, result)
-
-    def test_lookup__not_match(self):
+    def test_find__not_found(self):
         lookup_fields = ('arg1',)
         cache = ObjectCache(lookup_fields)
         obj = MyClass(1, 2)
 
-        cache.cache_instance(obj)
-        result = cache.lookup(lookup_fields, {'arg1': 2})
+        cache.add(obj)
+        result = cache.find(2)
 
         self.assertIsNone(result)
 
-    def test_lookup__multiple_results(self):
+    def test_find__multiple_results(self):
         lookup_fields = ('arg1',)
         cache = ObjectCache(lookup_fields)
         obj1 = MyClass(1, 2)
         obj2 = MyClass(1, 3)
 
-        cache.cache_instance(obj1)
-        cache.cache_instance(obj2)
+        cache.add(obj1)
+        cache.add(obj2)
 
         with self.assertRaises(cache.multiple_objects_error):
-            cache.lookup(lookup_fields, {'arg1': 1})
+            cache.find(1)
 
-    def test_lookup_value(self):
+    def test_match(self):
         lookup_fields = ('arg1',)
         cache = ObjectCache(lookup_fields)
         obj = MyClass(1, 2)
 
-        cache.cache_instance(obj)
-        result = cache.lookup_value(1)
+        cache.add(obj)
+        result = cache.match({'arg1': 1})
 
         self.assertEqual(obj, result)
 
-    def test_lookup_value__value_pair(self):
+    def test_match__value_pair(self):
         lookup_fields = ('arg1', ('arg2', 'arg3'))
         cache = ObjectCache(lookup_fields)
         obj1 = MyClass(1, 2, 3)
         obj2 = MyClass(1, 2, 4)
         obj3 = MyClass(1, 4, 3)
 
-        cache.cache_instance(obj1)
-        cache.cache_instance(obj2)
-        cache.cache_instance(obj3)
-        result = cache.lookup_value([2, 3])
+        cache.add(obj1)
+        cache.add(obj2)
+        cache.add(obj3)
+        result = cache.match({'arg1': 2, 'arg2': 2, 'arg3': 3})
 
         self.assertEqual(obj1, result)
 
-    def test_lookup_value__value_pair_not_found(self):
-        lookup_fields = ('arg1', ('arg2', 'arg3'))
-        cache = ObjectCache(lookup_fields)
-        obj1 = MyClass(1, 2, 3)
-        obj2 = MyClass(1, 2, 4)
-        obj3 = MyClass(1, 4, 3)
-
-        cache.cache_instance(obj1)
-        cache.cache_instance(obj2)
-        cache.cache_instance(obj3)
-        result = cache.lookup_value([1, 3])
-
-        self.assertIsNone(result)
-
-    def test_lookup_value__not_found(self):
+    def test_match__not_match(self):
         lookup_fields = ('arg1',)
         cache = ObjectCache(lookup_fields)
         obj = MyClass(1, 2)
 
-        cache.cache_instance(obj)
-        result = cache.lookup_value(2)
+        cache.add(obj)
+        result = cache.match({'arg1': 2})
 
         self.assertIsNone(result)
 
-    def test_lookup_value__multiple_results(self):
+    def test_match__multiple_results(self):
         lookup_fields = ('arg1',)
         cache = ObjectCache(lookup_fields)
         obj1 = MyClass(1, 2)
         obj2 = MyClass(1, 3)
 
-        cache.cache_instance(obj1)
-        cache.cache_instance(obj2)
+        cache.add(obj1)
+        cache.add(obj2)
 
         with self.assertRaises(cache.multiple_objects_error):
-            cache.lookup_value(1)
+            cache.match({'arg1': 1})
 
     def test_len(self):
         lookup_fields = ('arg1',)
@@ -170,5 +142,5 @@ class ObjectCacheTests(TestCase):
 
         for i in range(1, 10):
             obj = MyClass(i)
-            cache.cache_instance(obj)
+            cache.add(obj)
             self.assertEqual(len(cache), i)


### PR DESCRIPTION
This will allow us to specify `lookup_fields` like so:

    lookup_fields = (
        'universal_id',
        ('item_id', 'title'),
    )

Where we try to find a match on `universal_id` first, and then if no luck, try to match on both `item_id` and `title`.