### PR TITLE
Update tablib to a more secure version

### DIFF
--- a/multi_import/formats.py
+++ b/multi_import/formats.py
@@ -58,14 +58,22 @@ class TabLibFileFormat(FileFormat):
         return False
 
     def pre_read(self, file_object):
-        return file_object.read()
+        return file_object
 
     def read(self, file_handler, file_contents):
         file_object = self.get_file_object(file_handler, file_contents)
         file_object = self.pre_read(file_object)
+
         try:
             dataset = Dataset()
-            self.format.import_set(dataset, file_object)
+
+            try:
+                self.format.import_set(dataset, file_object)
+            except TypeError:
+                # Versions of tablib>=0.11.5 expect a
+                # buffer-like object to pass to BytesIO
+                self.format.import_set(dataset, file_object.read())
+
             return dataset
         except AttributeError:
             raise InvalidFileError(_(u'Empty or Invalid File.'))

--- a/multi_import/formats.py
+++ b/multi_import/formats.py
@@ -58,14 +58,14 @@ class TabLibFileFormat(FileFormat):
         return False
 
     def pre_read(self, file_object):
-        return file_object
+        return file_object.read()
 
     def read(self, file_handler, file_contents):
         file_object = self.get_file_object(file_handler, file_contents)
         file_object = self.pre_read(file_object)
         try:
             dataset = Dataset()
-            self.format.import_set(dataset, self.pre_read(file_object))
+            self.format.import_set(dataset, file_object)
             return dataset
         except AttributeError:
             raise InvalidFileError(_(u'Empty or Invalid File.'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django>=1.8                             # BSD
+Django<2.0                              # BSD
 djangorestframework==3.3.3              # BSD
 six==1.10.0                             # MIT
 chardet==2.3.0                          # LGPL
-tablib==0.11.2                          # MIT
+tablib==0.12.1                          # MIT
 
 coverage==4.2                           # Apache
 flake8==3.0.4                           # MIT


### PR DESCRIPTION
Also update how tablib files are read, since tablib now expects something
that can be passed to BytesIO().

The tablib<=0.11.4 vulnerability:  
https://www.cvedetails.com/cve/CVE-2017-2810