### PR TITLE
Update for Python 3 changes

### DIFF
--- a/multi_import/data.py
+++ b/multi_import/data.py
@@ -17,6 +17,7 @@ class Row(object):
     """
     Represents a row in an imported Dataset
     """
+
     def __init__(self, row_number, line_number, data):
         self.row_number = row_number
         self.line_number = line_number
@@ -119,6 +120,7 @@ class MultiImportResult(object):
     """
     Results from an attempt to generate an import diff for several files.
     """
+
     def __init__(self):
         self.files = []
         self.errors = {}

--- a/multi_import/formats.py
+++ b/multi_import/formats.py
@@ -1,4 +1,5 @@
 import chardet
+import six
 from django.utils.translation import ugettext_lazy as _
 from tablib.formats import _csv, _xls, _xlsx
 from tablib.core import Dataset
@@ -81,6 +82,8 @@ class TabLibFileFormat(FileFormat):
     def write(self, dataset):
         data = self.format.export_set(dataset)
         f = BytesIO()
+        if isinstance(data, six.text_type):
+            data = data.encode('utf-8')
         f.write(data)
         return f
 
@@ -93,6 +96,8 @@ class CsvFormat(TabLibFileFormat):
 
     @classmethod
     def ensure_unicode(cls, file_contents):
+        if isinstance(file_contents, six.text_type):
+            return file_contents
         charset = chardet.detect(file_contents)
         encoding = charset['encoding']
         encoding_confidence = charset['confidence']

--- a/multi_import/helpers/files.py
+++ b/multi_import/helpers/files.py
@@ -15,14 +15,27 @@ def find_format(file_formats, file_format=None):
     )
 
 
+def decode_contents(file_contents):
+    encodings = ['UTF-8', 'UTF-16', 'ISO-8859-1']
+
+    for encoding in encodings:
+        try:
+            return file_contents.decode(encoding)
+        except UnicodeDecodeError:
+            pass
+
+    raise InvalidFileError(_(u'File encoding not identified.'))
+
+
 def read(file_formats, file):
     file.seek(0)
     file_contents = file.read()
+    decoded_file_contents = decode_contents(file_contents)
 
     for file_format in file_formats:
         try:
-            if file_format.detect(file, file_contents):
-                return file_format.read(file, file_contents)
+            if file_format.detect(file, decoded_file_contents):
+                return file_format.read(file, decoded_file_contents)
 
         except AttributeError:
             pass

--- a/multi_import/importer.py
+++ b/multi_import/importer.py
@@ -223,7 +223,7 @@ class Importer(object):
         except InvalidFileError as e:
             return ImportResult(
                 key=self.key,
-                error=e.message
+                error=str(e)
             )
 
         return self.import_data(dataset, transaction=False)

--- a/multi_import/multi_importer.py
+++ b/multi_import/multi_importer.py
@@ -65,7 +65,7 @@ class MultiImporter(object):
                 else:
                     data[model] = [data_item]
             except(InvalidDatasetError, InvalidFileError) as e:
-                results.add_error(filename, e.message)
+                results.add_error(filename, str(e))
 
         if not results.valid:
             return results

--- a/tests/test_helpers_files.py
+++ b/tests/test_helpers_files.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import chardet
+from django.test import TestCase
+from six import BytesIO
+
+from multi_import.helpers import files
+
+
+class FileHelperTests(TestCase):
+
+    def test_decode_file_when_reading_utf_8(self):
+        file = BytesIO()
+        file.write(u'UTF-8 character: Đà'.encode('utf-8'))
+
+        file.seek(0)
+        file_contents = file.read()
+        charset = chardet.detect(file_contents)
+        encoding = charset['encoding']
+
+        self.assertEqual('utf-8', encoding)
+
+        decoded_file_contents = files.decode_contents(file_contents)
+        self.assertTrue(type(decoded_file_contents), str)
+
+    def test_decode_file_when_reading_utf_16(self):
+        file = BytesIO()
+        file.write(u'UTF-16 character: $'.encode('utf-16'))
+
+        file.seek(0)
+        file_contents = file.read()
+        charset = chardet.detect(file_contents)
+        encoding = charset['encoding']
+
+        self.assertEqual('UTF-16', encoding)
+
+        decoded_file_contents = files.decode_contents(file_contents)
+        self.assertTrue(type(decoded_file_contents), str)
+
+    def test_decode_file_when_reading_iso_8859_1(self):
+        file = BytesIO()
+        file.write(u'Latin-1 character: ¥'.encode('ISO-8859-1'))
+
+        file.seek(0)
+        file_contents = file.read()
+        charset = chardet.detect(file_contents)
+        encoding = charset['encoding']
+
+        # Latin-1 and ISO-8859-1 are equivalent.
+        self.assertEqual('ISO-8859-1', encoding)
+
+        decoded_file_contents = files.decode_contents(file_contents)
+        self.assertTrue(type(decoded_file_contents), str)


### PR DESCRIPTION
Updated some files in this pull request in response to Python 3 changes:
* Python 3 differentiates `str` and `bytes` now: 
  * Further reference for unicode, str, bytes in Python 3: https://medium.com/better-programming/strings-unicode-and-bytes-in-python-3-everything-you-always-wanted-to-know-27dc02ff2686
  * Files are being read as `bytes` initially and we decode it into `str` to manipulate the data.
  * in ensure_unicode(..) in formats.py:
    * now returns file_contents if file_contents is unicode str.
      * check file_contents is using unicode str, by `isinstance(file_contents, six.text_type)`
    * existing code for the case when file_contents is bytes is untouched.
* `Exception` doesn't have `message` attribute anymore:
    * instead, Python 3 recommends using `str()` string representation:
      * Reference: https://www.python.org/dev/peps/pep-0352/

## TODO:
- [ ] Check this new fix works both in Python 2 and 3 environments
    - Found an error when importing csv in Python 2 environment 
- [ ] Check the new test passes both in Python 2 and 3 environment
- [ ] Check if library.tests.test_import_export passes both in Python 2 and 3 environments

Refs #SDE-7555