### PR TITLE
Add Python3 compatibility for normalizing row data

### DIFF
--- a/multi_import/importer.py
+++ b/multi_import/importer.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import MultipleObjectsReturned
 from django.utils.translation import ugettext_lazy as _
-from six import string_types
+from six import string_types, text_type
 from tablib import Dataset
 
 from multi_import.cache import CachedQuery, ObjectCache
@@ -104,7 +104,7 @@ class DataReader(object):
                 value = int(value)
 
             if not isinstance(value, string_types):
-                value = unicode(value)
+                value = text_type(value)
 
             data[key] = strings.normalize_string(value)
         return data


### PR DESCRIPTION
## Description

This commit fixes an issue that arises when importing .xlsx files that have cells that contain non-strings (floats, ints).  

## Problem

`unicode` was being called to convert number data to text, but this only works for python2. 

## Fix

Change `unicode` to `text_type`, which is both Python2 and Python3 compatible.

_Note: Once this is merged we will need to create a new tag._

## Testing notes

The file below can be used for testing in SDE:

[test_task.xlsx](https://github.com/sdelements/django-multi-import/files/3924510/test_task.xlsx)


refs [LIBR-53](https://sdelements.atlassian.net/browse/LIBR-53)

