### PR TITLE
Add support for multiple serializers per importer

### DIFF
--- a/multi_import/data.py
+++ b/multi_import/data.py
@@ -29,9 +29,11 @@ class Row(object):
 
     def set_error(self, message):
         self.errors = {api_settings.NON_FIELD_ERRORS_KEY: [message]}
+        self.status = None
 
     def set_errors(self, errors):
         self.errors = errors
+        self.status = None
 
     def to_json(self):
         return {

--- a/multi_import/helpers/serializers.py
+++ b/multi_import/helpers/serializers.py
@@ -127,34 +127,37 @@ def might_have_changes(serializer):
     return old_values != new_values
 
 
-def get_diff_data(serializer):
-    if not has_changes(serializer):
-        return None
-
+def get_diff_data(serializer, no_changes=None):
     data = {}
 
-    changed_fields = get_changed_fields(serializer)
-    orig = get_original_representation(serializer)
+    changed_fields = {}
+    orig = {}
 
-    for column_name in serializer.initial_data:
+    if not no_changes:
+        changed_fields = get_changed_fields(serializer)
+        orig = get_original_representation(serializer)
+
+    for column_name, value in serializer.initial_data.items():
         field = serializer.fields.get(column_name, None)
         if not field:
             continue
 
         data[column_name] = field_data = []
 
-        if column_name in orig:
-            field_data.append(fields.to_string_representation(field, orig[column_name]))
-        else:
-            field_data.append(u"")
-
         field_change = changed_fields.get(column_name, None)
 
-        if not field_change:
-            continue
+        if field_change:
+            if column_name in orig:
+                field_data.append(
+                    fields.to_string_representation(field, orig[column_name])
+                )
+            else:
+                field_data.append(u"")
 
-        new_value = field_change.new
+            new_value = field_change.new
 
-        field_data.append(fields.to_string_representation(field, new_value))
+            field_data.append(fields.to_string_representation(field, new_value))
+        else:
+            field_data.append(fields.to_string_representation(field, value))
 
     return data

--- a/multi_import/multi_importer.py
+++ b/multi_import/multi_importer.py
@@ -104,14 +104,23 @@ class MultiImporter(object):
                 ]
             )
 
+        max_steps = max(
+            len(importer.get_serializer_classes())
+            for importer, _rows, _filename, serializer_context in read_datasets
+        )
+
         for importer, rows, _filename, serializer_context in read_datasets:
             importer.load_instances(rows, serializer_context)
 
-        for importer, rows, _filename, serializer_context in read_datasets:
-            importer.process_rows(rows, serializer_context)
+        for step in range(max_steps):
+            for importer, rows, _filename, serializer_context in read_datasets:
+                importer.process_rows(rows, serializer_context, step)
 
         for importer, rows, _filename, _serializer_context in read_datasets:
             importer.validate_rows_post_save(rows)
+
+        for importer, rows, _filename, _serializer_context in read_datasets:
+            importer.process_diffs(rows)
 
         for importer, rows, filename, _serializer_context in read_datasets:
             result = importer.transform_rows_to_result(rows)

--- a/tests/test_helpers_serializers.py
+++ b/tests/test_helpers_serializers.py
@@ -152,7 +152,9 @@ class SerializerHelperTests(TestCase):
 
         diff = serializers.get_diff_data(serializer)
 
-        self.assertEqual(diff, None)
+        self.assertEqual(
+            diff, {"first_name": ["Justin"], "last_name": ["Trudeau"], "partner": [""]}
+        )
 
     def test_get_diff_data_for_exisiting_object_with_changes(self):
         justin = Person(first_name="Justin", last_name="Trudeau")


### PR DESCRIPTION
### Background

This library is designed so that users can import a number of files, each one relating to a different django model.

Say I have this object model:

* `Author`
* `Blog`
* `Article`

Each model is dependent on the prior model.

This library is designed so that it checks the relationships between different files (importers), so that the files can be processed in the correct order.

### Problem

What if each author has a favourite article?

I want to add a `favourite_article` column to the `author` file. But we'll run into an issue where, maybe the article doesn't exist, because it references a blog, that it in turns references an author.

We have a circular reference.

### Solution

This pull request adds the ability to specify multiple serializers per importer.

Then when importing files, we'll do multiple passes across the files - using a serializer per pass.

### Example

We'd define classes like this:

```python
# Serializers
class AuthorSerializer:
    author_id = IntegerField()
    name = CharField()

class AuthorFavouritePostSerializer:
    favourite_article = ForeignKeyField("Article")

class BlogSerializer:
   blog_id = IntegerField()
    author = ForeignKeyField("Author")
    title = CharField()

class ArticleSerializer:
    article_id = IntegerField()
    blog = ForeignKeyField("Blog")
    title = CharField()
    body = CharField()

# Importers
class AuthorImporter:
    serializer_classes = (AuthorSerializer, AuthorFavouritePostSerializer)

class BlogImporter:
    serializer_class = BlogSerializer

class ArticleSerializer:
    serializer_class = ArticleSerializer
```

Which would lead the files being processed like this:

1. Process authors using `AuthorSerializer`
2. Process blogs using `BlogSerializer`
3. Process articles using `ArticleSerializer`
4. Perform a second pass on authors using `AuthorFavouritePostSerializer`