### PR TITLE
Error raised when MultipleObjectsReturned

### DIFF
--- a/multi_import/importer.py
+++ b/multi_import/importer.py
@@ -308,6 +308,7 @@ class Importer(object):
 
     def load_instance(self, row, data, context):
         cached_query = context["cached_query"]
+        instance = None
         try:
             lookup_data = self.get_lookup_data(row)
             instance = self.lookup_model_object(cached_query, lookup_data)


### PR DESCRIPTION
Import raises the following error when items being imported are not unique:
`UnboundLocalError: local variable 'instance' referenced before assignment`

This MR fixes the issue by assigning a default value to the `instance` varable.