### PR TITLE
Add text/yaml mime type

### DIFF
--- a/multi_import/formats.py
+++ b/multi_import/formats.py
@@ -216,6 +216,7 @@ supported_mimetypes = (
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "application/json",
     "application/x-yaml",
+    "text/yaml",
     # When Content-Type unspecified, defaults to this.
     # https://sdelements.atlassian.net/browse/LIBR-355
     # https://stackoverflow.com/questions/12061030/why-am-i-getting-mime-type-of-csv-file-as-application-octet-stream


### PR DESCRIPTION
While running cypress yaml files were being uploaded using the "text/yaml" mime type which is currently unsupported.

- Added support for "text/yaml" mime type