### PR TITLE
Export chunking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 docs/_build/*
 dist/*
 *.swp
+.vscode/*

--- a/multi_import/formats.py
+++ b/multi_import/formats.py
@@ -1,11 +1,11 @@
 import chardet
 import six
-from yaml import CSafeDumper
-
 from django.utils.translation import ugettext_lazy as _
-from tablib.formats import _csv, _json, _xls, _xlsx, _yaml
-from tablib.core import Dataset
 from tablib.compat import BytesIO, StringIO
+from tablib.core import Dataset
+from tablib.formats import _csv, _json, _xls, _xlsx, _yaml
+from typing_extensions import OrderedDict
+from yaml import CSafeDumper
 
 from multi_import.exceptions import InvalidFileError
 from multi_import.helpers import strings
@@ -91,8 +91,12 @@ class TabLibFileFormat(FileFormat):
     def export_set(self, dataset):
         return self.format.export_set(dataset)
 
-    def write(self, dataset):
+    def write(self, dataset: Dataset) -> BytesIO:
+        """Return a BytesIO stream representing a set of items."""
         data = self.export_set(dataset)
+        return self._write_to_bytes(data)
+
+    def _write_to_bytes(self, data) -> BytesIO:
         f = BytesIO()
         if isinstance(data, six.text_type):
             data = data.encode("utf-8")

--- a/multi_import/importer.py
+++ b/multi_import/importer.py
@@ -209,6 +209,7 @@ class Importer(object):
             example_row=self.get_example_row(serializers),
             file_formats=self.file_formats,
             filename=self.get_export_filename(),
+            id_column=self.id_column,
         )
 
     def get_export_header(self, serializers):


### PR DESCRIPTION
# Overview

A number of users use git to version control content. Currently, the multi exporter exports content in files grouped by their content type. This can be problematic for git if there are enough content items of a particular type as the file sizes will be large and the git tools (e.g. Github) will not be able to render them. This prevents users from being able to view/comment on the files.

The PR adds the ability for the multi importer to export content items in individual files. This ensures that each file size is kept low. 

Refs #[LIBR-970](https://sdelements.atlassian.net/browse/LIBR-970) #[LIBR-1023](https://sdelements.atlassian.net/browse/LIBR-1023) 