### PR TITLE
JSON and YAML export_set fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,8 +30,8 @@ jobs:
           poetry install
       - name: Linting
         run: |
-          poetry run isort .
-          poetry run black .
+          poetry run black --check .
+          poetry run isort --check-only .
           poetry run flake8 . --extend-ignore=D,E501,W601 --extend-exclude=docs/ --statistics --count
       - name: Security
         run: poetry run bandit -c pyproject.toml -r .

--- a/multi_import/fields.py
+++ b/multi_import/fields.py
@@ -1,5 +1,9 @@
-from django.core.exceptions import (FieldError, MultipleObjectsReturned,
-                                    ObjectDoesNotExist, ValidationError)
+from django.core.exceptions import (
+    FieldError,
+    MultipleObjectsReturned,
+    ObjectDoesNotExist,
+    ValidationError,
+)
 from django.utils.translation import gettext_lazy as _
 from rest_framework import relations
 

--- a/multi_import/formats.py
+++ b/multi_import/formats.py
@@ -1,9 +1,9 @@
+import json as pyjson
 from csv import Error as NullError
 from io import BytesIO, StringIO
 
 import chardet
-from json import dumps as json_dumps
-from yaml import dump as yaml_dump, safe_dump as yaml_safe_dump
+import yaml as pyyaml
 from django.utils.translation import gettext_lazy as _
 from tablib.core import Dataset, InvalidDimensions, UnsupportedFormat
 from tablib.formats import registry
@@ -150,7 +150,7 @@ class JsonFormat(TabLibFileFormat):
         )
 
     def export_set(self, dataset):
-        return json_dumps(
+        return pyjson.dumps(
             dataset.dict,
             ensure_ascii=False,
             sort_keys=False,
@@ -168,7 +168,7 @@ class YamlFormat(TabLibFileFormat):
         # By default use the C-based CSafeDumper,
         # otherwise fallback to pure Python SafeDumper.
         if CSafeDumper:
-            return yaml_dump(
+            return pyyaml.dump(
                 dataset._package(),
                 Dumper=CSafeDumper,
                 allow_unicode=True,
@@ -176,7 +176,7 @@ class YamlFormat(TabLibFileFormat):
                 sort_keys=False,
             )
         else:
-            return yaml_safe_dump(
+            return pyyaml.safe_dump(
                 dataset._package(),
                 allow_unicode=True,
                 default_flow_style=False,

--- a/multi_import/formats.py
+++ b/multi_import/formats.py
@@ -2,6 +2,8 @@ from csv import Error as NullError
 from io import BytesIO, StringIO
 
 import chardet
+from json import dumps as json_dumps
+from yaml import dump as yaml_dump, safe_dump as yaml_safe_dump
 from django.utils.translation import gettext_lazy as _
 from tablib.core import Dataset, InvalidDimensions, UnsupportedFormat
 from tablib.formats import registry
@@ -148,9 +150,8 @@ class JsonFormat(TabLibFileFormat):
         )
 
     def export_set(self, dataset):
-        return _json.json.dumps(
+        return json_dumps(
             dataset.dict,
-            default=_json.date_handler,
             ensure_ascii=False,
             sort_keys=False,
             indent=2,
@@ -167,16 +168,16 @@ class YamlFormat(TabLibFileFormat):
         # By default use the C-based CSafeDumper,
         # otherwise fallback to pure Python SafeDumper.
         if CSafeDumper:
-            return _yaml.yaml.dump(
-                dataset._package(ordered=False),
+            return yaml_dump(
+                dataset._package(),
+                Dumper=CSafeDumper,
                 allow_unicode=True,
                 default_flow_style=False,
                 sort_keys=False,
-                Dumper=CSafeDumper,
             )
         else:
-            return _yaml.yaml.safe_dump(
-                dataset._package(ordered=False),
+            return yaml_safe_dump(
+                dataset._package(),
                 allow_unicode=True,
                 default_flow_style=False,
                 sort_keys=False,

--- a/poetry.lock
+++ b/poetry.lock
@@ -206,17 +206,17 @@ tokenize-rt = ">=4.1"
 
 [[package]]
 name = "djangorestframework"
-version = "3.15.1"
+version = "3.15.2"
 description = "Web APIs for Django, made easy."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "djangorestframework-3.15.1-py3-none-any.whl", hash = "sha256:3ccc0475bce968608cf30d07fb17d8e52d1d7fc8bfe779c905463200750cbca6"},
-    {file = "djangorestframework-3.15.1.tar.gz", hash = "sha256:f88fad74183dfc7144b2756d0d2ac716ea5b4c7c9840995ac3bfd8ec034333c1"},
+    {file = "djangorestframework-3.15.2-py3-none-any.whl", hash = "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20"},
+    {file = "djangorestframework-3.15.2.tar.gz", hash = "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad"},
 ]
 
 [package.dependencies]
-django = ">=3.0"
+django = ">=4.2"
 
 [[package]]
 name = "et-xmlfile"
@@ -231,18 +231,18 @@ files = [
 
 [[package]]
 name = "filelock"
-version = "3.14.0"
+version = "3.15.3"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.14.0-py3-none-any.whl", hash = "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f"},
-    {file = "filelock-3.14.0.tar.gz", hash = "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"},
+    {file = "filelock-3.15.3-py3-none-any.whl", hash = "sha256:0151273e5b5d6cf753a61ec83b3a9b7d8821c39ae9af9d7ecf2f9e2f17404103"},
+    {file = "filelock-3.15.3.tar.gz", hash = "sha256:e1199bf5194a2277273dacd50269f0d87d0682088a3c561c15674ea9005d8635"},
 ]
 
 [package.extras]
 docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)", "virtualenv (>=20.26.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
@@ -434,13 +434,13 @@ defusedxml = "*"
 
 [[package]]
 name = "openpyxl"
-version = "3.1.3"
+version = "3.1.4"
 description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "openpyxl-3.1.3-py2.py3-none-any.whl", hash = "sha256:25071b558db709de9e8782c3d3e058af3b23ffb2fc6f40c8f0c45a154eced2c3"},
-    {file = "openpyxl-3.1.3.tar.gz", hash = "sha256:8dd482e5350125b2388070bb2477927be2e8ebc27df61178709bc8c8751da2f9"},
+    {file = "openpyxl-3.1.4-py2.py3-none-any.whl", hash = "sha256:ec17f6483f2b8f7c88c57e5e5d3b0de0e3fb9ac70edc084d28e864f5b33bbefd"},
+    {file = "openpyxl-3.1.4.tar.gz", hash = "sha256:8d2c8adf5d20d6ce8f9bca381df86b534835e974ed0156dacefa76f68c1d69fb"},
 ]
 
 [package.dependencies]
@@ -448,13 +448,13 @@ et-xmlfile = "*"
 
 [[package]]
 name = "packaging"
-version = "24.0"
+version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
-    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,6 @@ build-backend = "poetry.core.masonry.api"
 exclude_dirs = [
   './tests/',
 ]
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-multi_import"
-version = "2.0.2"
+version = "2.0.3"
 homepage = "https://github.com/sdelements/django-multi-import"
 description = "Import/export multi Django resources together atomically."
 authors = ["Security Compass <contact@securitycompass.com>"]

--- a/tests/test_csv_format.py
+++ b/tests/test_csv_format.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 
 from multi_import.exceptions import InvalidFileError
 from multi_import.formats import csv
-from multi_import.helpers.files import decode_contents, read as multi_import_read
+from multi_import.helpers.files import decode_contents
+from multi_import.helpers.files import read as multi_import_read
 
 
 class CSVFormatTest(TestCase):
@@ -22,7 +23,7 @@ class CSVFormatTest(TestCase):
         invalid_files = [
             "tests/fixtures/test_file.yaml",
             "tests/fixtures/test_file.json",
-            "tests/fixtures/test_file.xlsx"
+            "tests/fixtures/test_file.xlsx",
         ]
         for invalid_file in invalid_files:
             with open(invalid_file, "rb") as file:
@@ -34,13 +35,35 @@ class CSVFormatTest(TestCase):
                     file_handler=file, file_contents=decoded_contents
                 )
 
-                self.assertFalse(file_detection_result, "Expected %s to be an invalid file" % invalid_file)
+                self.assertFalse(
+                    file_detection_result,
+                    "Expected %s to be an invalid file" % invalid_file,
+                )
 
     def test_read_csv_file(self):
         with open("tests/fixtures/test_file.csv", "rb") as file:
             output = multi_import_read([csv], file)
 
-        expected_data = ('1', 'c0eb1608-7a75-11ee-b962-0242ac120002', 'Jedi', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.', 'lorem', '1', '00c5755c-7a76-11ee-b962-0242ac120002', '1900-11-20T13:47:10-04:00', '1900-11-20T13:47:10-04:00', 'mocha', 'True', 'mocha', '00c5755c-7a76-11ee-b962-0242ac120002', 'lorem', '', '', '', '')
+        expected_data = (
+            "1",
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "Jedi",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            "lorem",
+            "1",
+            "00c5755c-7a76-11ee-b962-0242ac120002",
+            "1900-11-20T13:47:10-04:00",
+            "1900-11-20T13:47:10-04:00",
+            "mocha",
+            "True",
+            "mocha",
+            "00c5755c-7a76-11ee-b962-0242ac120002",
+            "lorem",
+            "",
+            "",
+            "",
+            "",
+        )
 
         self.assertEqual(expected_data, output[0])
 
@@ -48,11 +71,9 @@ class CSVFormatTest(TestCase):
         invalid_files = [
             "tests/fixtures/test_file.yaml",
             "tests/fixtures/test_file.json",
-            "tests/fixtures/test_file.xlsx"
+            "tests/fixtures/test_file.xlsx",
         ]
 
         for invalid_file in invalid_files:
-            with open(invalid_file, "rb") as file, self.assertRaises(
-                InvalidFileError
-            ):
+            with open(invalid_file, "rb") as file, self.assertRaises(InvalidFileError):
                 multi_import_read([csv], file)

--- a/tests/test_json_format.py
+++ b/tests/test_json_format.py
@@ -1,8 +1,13 @@
+from io import StringIO
+from json import dumps as json_dumps
+
 from django.test import TestCase
+from tablib import Dataset
 
 from multi_import.exceptions import InvalidFileError
 from multi_import.formats import json
-from multi_import.helpers.files import decode_contents, read as multi_import_read
+from multi_import.helpers.files import decode_contents
+from multi_import.helpers.files import read as multi_import_read
 
 
 class JSONFormatTest(TestCase):
@@ -22,7 +27,7 @@ class JSONFormatTest(TestCase):
         invalid_files = [
             "tests/fixtures/test_file.yaml",
             "tests/fixtures/test_file.csv",
-            "tests/fixtures/test_file.xlsx"
+            "tests/fixtures/test_file.xlsx",
         ]
         for invalid_file in invalid_files:
             with open(invalid_file, "rb") as file:
@@ -34,13 +39,31 @@ class JSONFormatTest(TestCase):
                     file_handler=file, file_contents=decoded_contents
                 )
 
-                self.assertFalse(file_detection_result, "Expected %s to be an invalid file" % invalid_file)
+                self.assertFalse(
+                    file_detection_result,
+                    "Expected %s to be an invalid file" % invalid_file,
+                )
 
     def test_read_valid_file(self):
         with open("tests/fixtures/test_file.json", "rb") as file:
             output = multi_import_read([json], file)
 
-        expected_data = ('1', 'c0eb1608-7a75-11ee-b962-0242ac120002', 'Luke', 'Lorem ipsum dolor sit', 'Lorem ipsum dolor sit', '7', 'c0eb1608-7a75-11ee-b962-0242ac120002', '1900-10-20T13:47:10-04:00', '1901-03-10T04:03:03.622000-05:00', 'tea', 'True', 'tea', 'c0eb1608-7a75-11ee-b962-0242ac120002', '1')
+        expected_data = (
+            "1",
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "Luke",
+            "Lorem ipsum dolor sit",
+            "Lorem ipsum dolor sit",
+            "7",
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "1900-10-20T13:47:10-04:00",
+            "1901-03-10T04:03:03.622000-05:00",
+            "tea",
+            "True",
+            "tea",
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "1",
+        )
 
         self.assertEqual(expected_data, output[0])
 
@@ -48,11 +71,35 @@ class JSONFormatTest(TestCase):
         invalid_files = [
             "tests/fixtures/test_file.yaml",
             "tests/fixtures/test_file.csv",
-            "tests/fixtures/test_file.xlsx"
+            "tests/fixtures/test_file.xlsx",
         ]
 
         for invalid_file in invalid_files:
-            with open(invalid_file, "rb") as file, self.assertRaises(
-                InvalidFileError
-            ):
+            with open(invalid_file, "rb") as file, self.assertRaises(InvalidFileError):
                 multi_import_read([json], file)
+
+    def test_key_property(self):
+        self.assertEqual(json.key, "json")
+
+    def test_extension_property(self):
+        self.assertEqual(json.extension, "json")
+
+    def test_pre_read(self):
+        file_object = StringIO(json_dumps([{"name": "John", "age": 30}]))
+
+        self.assertEqual(json.pre_read(file_object), file_object)
+
+    def test_export_set(self):
+        sample_data = [{"name": "John", "age": 30}, {"name": "Jane", "age": 25}]
+
+        dataset = Dataset()
+        dataset.dict = sample_data
+        result = json.export_set(dataset)
+        expected = json_dumps(
+            sample_data,
+            ensure_ascii=False,
+            sort_keys=False,
+            indent=2,
+        )
+
+        self.assertEqual(result, expected)

--- a/tests/test_xlsx_format.py
+++ b/tests/test_xlsx_format.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 
 from multi_import.exceptions import InvalidFileError
 from multi_import.formats import xlsx
-from multi_import.helpers.files import decode_contents, read as multi_import_read
+from multi_import.helpers.files import decode_contents
+from multi_import.helpers.files import read as multi_import_read
 
 
 class XLSXFormatTest(TestCase):
@@ -22,7 +23,7 @@ class XLSXFormatTest(TestCase):
         invalid_files = [
             "tests/fixtures/test_file.yaml",
             "tests/fixtures/test_file.csv",
-            "tests/fixtures/test_file.json"
+            "tests/fixtures/test_file.json",
         ]
         for invalid_file in invalid_files:
             with open(invalid_file, "rb") as file:
@@ -34,13 +35,31 @@ class XLSXFormatTest(TestCase):
                     file_handler=file, file_contents=decoded_contents
                 )
 
-                self.assertFalse(file_detection_result, "Expected %s to be an invalid file" % invalid_file)
+                self.assertFalse(
+                    file_detection_result,
+                    "Expected %s to be an invalid file" % invalid_file,
+                )
 
     def test_read_valid_file(self):
         with open("tests/fixtures/test_file.xlsx", "rb") as file:
             output = multi_import_read([xlsx], file)
 
-        expected_data = (1, 'c0eb1608-7a75-11ee-b962-0242ac120002', 'Lorem', 'Lorem', 'ipsum', 2, 'i[sum', '1900-10-20T13:47:10-04:00', '1901-03-10T04:03:03.622000-05:00', 'ice tea', 'True', 'ice tea', 'c0eb1608-7a75-11ee-b962-0242ac120002', 1)
+        expected_data = (
+            1,
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "Lorem",
+            "Lorem",
+            "ipsum",
+            2,
+            "i[sum",
+            "1900-10-20T13:47:10-04:00",
+            "1901-03-10T04:03:03.622000-05:00",
+            "ice tea",
+            "True",
+            "ice tea",
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            1,
+        )
 
         self.assertEqual(expected_data, output[0])
 
@@ -48,11 +67,9 @@ class XLSXFormatTest(TestCase):
         invalid_files = [
             "tests/fixtures/test_file.yaml",
             "tests/fixtures/test_file.csv",
-            "tests/fixtures/test_file.json"
+            "tests/fixtures/test_file.json",
         ]
 
         for invalid_file in invalid_files:
-            with open(invalid_file, "rb") as file, self.assertRaises(
-                InvalidFileError
-            ):
+            with open(invalid_file, "rb") as file, self.assertRaises(InvalidFileError):
                 multi_import_read([xlsx], file)

--- a/tests/test_yaml_format.py
+++ b/tests/test_yaml_format.py
@@ -1,8 +1,18 @@
+from io import StringIO
+
+import yaml as pyyaml
 from django.test import TestCase
+from tablib import Dataset
 
 from multi_import.exceptions import InvalidFileError
 from multi_import.formats import yaml
-from multi_import.helpers.files import decode_contents, read as multi_import_read
+from multi_import.helpers.files import decode_contents
+from multi_import.helpers.files import read as multi_import_read
+
+try:
+    from yaml import CSafeDumper
+except ImportError:
+    CSafeDumper = None
 
 
 class YAMLFormatTest(TestCase):
@@ -36,7 +46,7 @@ class YAMLFormatTest(TestCase):
     def test_detect_invalid_files(self):
         invalid_files = [
             "tests/fixtures/test_file.xlsx",
-            "tests/fixtures/test_file.csv"
+            "tests/fixtures/test_file.csv",
         ]
         for invalid_file in invalid_files:
             with open(invalid_file, "rb") as file:
@@ -48,7 +58,10 @@ class YAMLFormatTest(TestCase):
                     file_handler=file, file_contents=decoded_contents
                 )
 
-                self.assertFalse(file_detection_result, "Expected %s to be an invalid file" % invalid_file)
+                self.assertFalse(
+                    file_detection_result,
+                    "Expected %s to be an invalid file" % invalid_file,
+                )
 
     def test_read_valid_file(self):
         """
@@ -57,7 +70,15 @@ class YAMLFormatTest(TestCase):
         with open("tests/fixtures/test_file.yaml", "rb") as file:
             output = multi_import_read([yaml], file)
 
-        expected_data = (1, 'c0eb1608-7a75-11ee-b962-0242ac120002', 'student', '1', 'False', '', '')
+        expected_data = (
+            1,
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "student",
+            "1",
+            "False",
+            "",
+            "",
+        )
 
         self.assertEqual(expected_data, output[0])
 
@@ -65,7 +86,22 @@ class YAMLFormatTest(TestCase):
         with open("tests/fixtures/test_file.json", "rb") as file:
             output = multi_import_read([yaml], file)
 
-        expected_data = ('1', 'c0eb1608-7a75-11ee-b962-0242ac120002', 'Luke', 'Lorem ipsum dolor sit', 'Lorem ipsum dolor sit', '7', 'c0eb1608-7a75-11ee-b962-0242ac120002', '1900-10-20T13:47:10-04:00', '1901-03-10T04:03:03.622000-05:00', 'tea', 'True', 'tea', 'c0eb1608-7a75-11ee-b962-0242ac120002', '1')
+        expected_data = (
+            "1",
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "Luke",
+            "Lorem ipsum dolor sit",
+            "Lorem ipsum dolor sit",
+            "7",
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "1900-10-20T13:47:10-04:00",
+            "1901-03-10T04:03:03.622000-05:00",
+            "tea",
+            "True",
+            "tea",
+            "c0eb1608-7a75-11ee-b962-0242ac120002",
+            "1",
+        )
 
         self.assertEqual(expected_data, output[0])
 
@@ -76,7 +112,41 @@ class YAMLFormatTest(TestCase):
         ]
 
         for invalid_file in invalid_files:
-            with open(invalid_file, "rb") as file, self.assertRaises(
-                InvalidFileError
-            ):
+            with open(invalid_file, "rb") as file, self.assertRaises(InvalidFileError):
                 multi_import_read([yaml], file)
+
+    def test_key_property(self):
+        self.assertEqual(yaml.key, "yaml")
+
+    def test_extension_property(self):
+        self.assertEqual(yaml.extension, "yaml")
+
+    def test_pre_read(self):
+        file_object = StringIO(pyyaml.dump([{"name": "John", "age": 30}]))
+
+        self.assertEqual(yaml.pre_read(file_object), file_object)
+
+    def test_export_set(self):
+        sample_data = [{"name": "John", "age": 30}, {"name": "Jane", "age": 25}]
+
+        dataset = Dataset()
+        dataset.dict = sample_data
+        result = yaml.export_set(dataset)
+        if CSafeDumper:
+            expected = pyyaml.dump(
+                sample_data,
+                Dumper=CSafeDumper,
+                allow_unicode=True,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+        else:
+            expected = pyyaml.safe_dump(
+                sample_data,
+                Dumper=pyyaml.SafeDumper,
+                allow_unicode=True,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+
+        self.assertEqual(result, expected)


### PR DESCRIPTION
### Summary

- Fixes for missing attributes on the class.
- [json] Use `json.dumps()` function directly in `export_set()`.
- [yaml] Use `yaml.dump()` and `yaml.safe_dump()` function directly in `export_set()`.
- [yaml] Dropped keyword argument `ordered` as plain dicts are already ordered since Python 3.6 - https://github.com/jazzband/tablib/pull/581.

##### Related Links
- https://sdelements.atlassian.net/browse/PIE-1773

##### Ready for QA Checklist
- [x] Code Review
- [x] Dev QA
- [ ] Rebase and Squash
